### PR TITLE
[feat] 답변의 CRUD 기능 및 질문 조회 기능 구현

### DIFF
--- a/src/main/java/woohaengsi/qnadiary/answer/controller/AnswerController.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/controller/AnswerController.java
@@ -1,0 +1,25 @@
+package woohaengsi.qnadiary.answer.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.service.AnswerService;
+import woohaengsi.qnadiary.auth.jwt.JwtProvider;
+
+@RestController
+@RequiredArgsConstructor
+public class AnswerController {
+
+    private final AnswerService answerService;
+    private final JwtProvider jwtProvider;
+
+    @PostMapping("/answer")
+    public void create(@RequestHeader("Authorization") String accessToken, @RequestBody AnswerCreateRequest request) {
+        Long memberId = jwtProvider.decode(accessToken);
+        answerService.create(request, memberId);
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/answer/controller/AnswerController.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/controller/AnswerController.java
@@ -1,12 +1,17 @@
 package woohaengsi.qnadiary.answer.controller;
 
-import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.dto.AnswerDetailResponse;
 import woohaengsi.qnadiary.answer.service.AnswerService;
 import woohaengsi.qnadiary.auth.jwt.JwtProvider;
 
@@ -18,8 +23,32 @@ public class AnswerController {
     private final JwtProvider jwtProvider;
 
     @PostMapping("/answer")
-    public void create(@RequestHeader("Authorization") String accessToken, @RequestBody AnswerCreateRequest request) {
-        Long memberId = jwtProvider.decode(accessToken);
-        answerService.create(request, memberId);
+    public Map<String, Long> create(@RequestHeader("Authorization") String accessToken, @RequestBody AnswerCreateRequest request) {
+        Long memberId = decodeAccessToken(accessToken);
+        return answerService.create(request, memberId);
+    }
+
+    @GetMapping("/answers/{id}")
+    public AnswerDetailResponse findById(@RequestHeader("Authorization") String accessToken, @PathVariable("id") Long id) {
+        Long memberId = decodeAccessToken(accessToken);
+        return answerService.findBy(id, memberId);
+    }
+
+    @PatchMapping("/answers/{id}")
+    public void updateAnswer(@RequestHeader("Authorization") String accessToken,
+        @PathVariable("id") Long id, @RequestBody String content) {
+        Long memberId = decodeAccessToken(accessToken);
+        answerService.update(id, memberId, content);
+    }
+
+    @DeleteMapping("/answers/{id}")
+    public void deleteAnswer(@RequestHeader("Authorization") String accessToken,
+        @PathVariable("id") Long id) {
+        Long memberId = decodeAccessToken(accessToken);
+        answerService.delete(id, memberId);
+    }
+
+    private Long decodeAccessToken(String accessToken) {
+        return jwtProvider.decode(accessToken);
     }
 }

--- a/src/main/java/woohaengsi/qnadiary/answer/domain/Answer.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/domain/Answer.java
@@ -35,4 +35,8 @@ public class Answer extends BaseEntity {
         this.question = question;
         this.content = content;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/woohaengsi/qnadiary/answer/dto/AnswerCreateRequest.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/dto/AnswerCreateRequest.java
@@ -1,0 +1,4 @@
+package woohaengsi.qnadiary.answer.dto;
+
+public record AnswerCreateRequest(Long questionId, String content) {
+}

--- a/src/main/java/woohaengsi/qnadiary/answer/dto/AnswerDetailResponse.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/dto/AnswerDetailResponse.java
@@ -1,0 +1,38 @@
+package woohaengsi.qnadiary.answer.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import woohaengsi.qnadiary.answer.domain.Answer;
+
+@Getter
+public class AnswerDetailResponse {
+    private final Long id;
+    private final String question;
+    private final String answer;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime lastModifiedAt;
+
+    @Builder
+    private AnswerDetailResponse(Long id, String question, String answer, LocalDateTime createdAt,
+        LocalDateTime lastModifiedAt) {
+        this.id = id;
+        this.question = question;
+        this.answer = answer;
+        this.createdAt = createdAt;
+        this.lastModifiedAt = lastModifiedAt;
+    }
+
+    public static AnswerDetailResponse of(Answer answer) {
+        return AnswerDetailResponse.builder()
+            .id(answer.getId())
+            .question(answer.getQuestion().getContent())
+            .answer(answer.getContent())
+            .createdAt(answer.getCreatedAt())
+            .lastModifiedAt(answer.getLastModifiedAt())
+            .build();
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/answer/repository/AnswerRepository.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/repository/AnswerRepository.java
@@ -1,10 +1,13 @@
 package woohaengsi.qnadiary.answer.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import woohaengsi.qnadiary.answer.domain.Answer;
+import woohaengsi.qnadiary.member.domain.Member;
 
 @Repository
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
 
+    Optional<Answer> findByIdAndMember(Long id, Member member);
 }

--- a/src/main/java/woohaengsi/qnadiary/answer/repository/AnswerRepository.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/repository/AnswerRepository.java
@@ -1,0 +1,10 @@
+package woohaengsi.qnadiary.answer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import woohaengsi.qnadiary.answer.domain.Answer;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<Answer, Long> {
+
+}

--- a/src/main/java/woohaengsi/qnadiary/answer/service/AnswerService.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/service/AnswerService.java
@@ -1,10 +1,13 @@
 package woohaengsi.qnadiary.answer.service;
 
+import java.util.Collections;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import woohaengsi.qnadiary.answer.domain.Answer;
 import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.dto.AnswerDetailResponse;
 import woohaengsi.qnadiary.answer.repository.AnswerRepository;
 import woohaengsi.qnadiary.member.domain.Member;
 import woohaengsi.qnadiary.member.repository.MemberRepository;
@@ -22,11 +25,35 @@ public class AnswerService {
 
 
     @Transactional
-    public void create(AnswerCreateRequest request, Long memberId) {
+    public Map<String, Long> create(AnswerCreateRequest request, Long memberId) {
         Member findMember = findMemberBy(memberId);
         Question findQuestion = findQuestionBy(request.questionId());
         Answer createdAnswer = new Answer(findMember, findQuestion, request.content());
         answerRepository.save(createdAnswer);
+        findMember.increaseCurrentQuestionNumber();
+        return Collections.singletonMap("questionId", findQuestion.getId());
+    }
+
+    public AnswerDetailResponse findBy(Long answerId, Long memberId) {
+        Member findMember = findMemberBy(memberId);
+        Answer findAnswer = answerRepository.findByIdAndMember(answerId, findMember)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답변입니다."));
+        return AnswerDetailResponse.of(findAnswer);
+    }
+    @Transactional
+    public void update(Long answerId, Long memberId, String content) {
+        Member findMember = findMemberBy(memberId);
+        Answer findAnswer = answerRepository.findByIdAndMember(answerId, findMember)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답변입니다."));
+        findAnswer.updateContent(content);
+    }
+
+    @Transactional
+    public void delete(Long answerId, Long memberId) {
+        Member findMember = findMemberBy(memberId);
+        Answer findAnswer = answerRepository.findByIdAndMember(answerId, findMember)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 답변입니다."));
+        answerRepository.delete(findAnswer);
     }
 
     private Member findMemberBy(Long memberId) {

--- a/src/main/java/woohaengsi/qnadiary/answer/service/AnswerService.java
+++ b/src/main/java/woohaengsi/qnadiary/answer/service/AnswerService.java
@@ -1,0 +1,41 @@
+package woohaengsi.qnadiary.answer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woohaengsi.qnadiary.answer.domain.Answer;
+import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.repository.AnswerRepository;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnswerService {
+
+    private final AnswerRepository answerRepository;
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+
+
+    @Transactional
+    public void create(AnswerCreateRequest request, Long memberId) {
+        Member findMember = findMemberBy(memberId);
+        Question findQuestion = findQuestionBy(request.questionId());
+        Answer createdAnswer = new Answer(findMember, findQuestion, request.content());
+        answerRepository.save(createdAnswer);
+    }
+
+    private Member findMemberBy(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    }
+
+    private Question findQuestionBy(Long questionId) {
+        return questionRepository.findById(questionId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 질문입니다."));
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/member/domain/Member.java
+++ b/src/main/java/woohaengsi/qnadiary/member/domain/Member.java
@@ -40,6 +40,7 @@ public class Member extends BaseEntity {
     private String emailAddress;
     private String profileImageUrl;
     private String refreshToken;
+    private Long currentQuestionNumber;
 
     @Builder
     private Member(ResourceServer resourceServer, String resourceServerId, String nickname,
@@ -50,6 +51,7 @@ public class Member extends BaseEntity {
         this.emailAddress = emailAddress;
         this.profileImageUrl = profileImageUrl;
         this.refreshToken = refreshToken;
+        this.currentQuestionNumber = 1L;
     }
 
     public static Member of(ResourceServer resourceServer, String resourceServerId, String nickname,
@@ -65,5 +67,9 @@ public class Member extends BaseEntity {
 
     public void updateRefreshToken(String newRefreshToken) {
         this.refreshToken = newRefreshToken;
+    }
+
+    public void increaseCurrentQuestionNumber() {
+        this.currentQuestionNumber++;
     }
 }

--- a/src/main/java/woohaengsi/qnadiary/question/controller/QuestionController.java
+++ b/src/main/java/woohaengsi/qnadiary/question/controller/QuestionController.java
@@ -1,0 +1,27 @@
+package woohaengsi.qnadiary.question.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import woohaengsi.qnadiary.auth.jwt.JwtProvider;
+import woohaengsi.qnadiary.question.dto.QuestionReadResponse;
+import woohaengsi.qnadiary.question.service.QuestionService;
+
+@RestController
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+    private final JwtProvider jwtProvider;
+
+    @GetMapping("/question")
+    public QuestionReadResponse find(@RequestHeader("Authorization") String accessToken) {
+        Long memberId = decodeAccessToken(accessToken);
+        return questionService.findBy(memberId);
+    }
+
+    private Long decodeAccessToken(String accessToken) {
+        return jwtProvider.decode(accessToken);
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/question/dto/QuestionReadResponse.java
+++ b/src/main/java/woohaengsi/qnadiary/question/dto/QuestionReadResponse.java
@@ -1,0 +1,25 @@
+package woohaengsi.qnadiary.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import woohaengsi.qnadiary.question.domain.Question;
+
+@Getter
+public class QuestionReadResponse {
+
+    private final Long id;
+    private final String content;
+
+    @Builder
+    private QuestionReadResponse(Long id, String content) {
+        this.id = id;
+        this.content = content;
+    }
+
+    public static QuestionReadResponse of(Question question) {
+        return QuestionReadResponse.builder()
+            .id(question.getId())
+            .content(question.getContent())
+            .build();
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/question/repository/QuestionRepository.java
+++ b/src/main/java/woohaengsi/qnadiary/question/repository/QuestionRepository.java
@@ -1,0 +1,10 @@
+package woohaengsi.qnadiary.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import woohaengsi.qnadiary.question.domain.Question;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+}

--- a/src/main/java/woohaengsi/qnadiary/question/service/QuestionService.java
+++ b/src/main/java/woohaengsi/qnadiary/question/service/QuestionService.java
@@ -1,0 +1,31 @@
+package woohaengsi.qnadiary.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.dto.QuestionReadResponse;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public QuestionReadResponse findBy(Long memberId) {
+        Member findMember = findMemberBy(memberId);
+        Question findQuestion = questionRepository.findById(findMember.getCurrentQuestionNumber())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 질문입니다."));
+        return QuestionReadResponse.of(findQuestion);
+    }
+
+    private Member findMemberBy(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,12 +2,6 @@ spring:
   profiles:
     default: local
 
-  datasource:
-    url: ${DATASOURCE_URL}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DATASOURCE_USERNAME}
-    password: ${DATASOURCE_PASSWORD}
-
   jpa:
     hibernate:
       ddl-auto: none
@@ -18,6 +12,7 @@ spring:
 
   config:
     import: classpath:oauth.yml
+
 
 ---
 spring:
@@ -34,6 +29,12 @@ spring:
         format_sql: true
     defer-datasource-initialization: true
 
+  datasource:
+    url: ${DATASOURCE_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+
 ---
 spring:
   config:
@@ -47,3 +48,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8://testDB
+    username:
+    password:
+    hikari:
+      maximum-pool-size: 5
+  sql:
+    init:
+      mode: never
+

--- a/src/test/java/woohaengsi/qnadiary/DatabaseCleanup.java
+++ b/src/test/java/woohaengsi/qnadiary/DatabaseCleanup.java
@@ -1,0 +1,40 @@
+package woohaengsi.qnadiary;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.shaded.com.google.common.base.CaseFormat;
+
+@Service
+public class DatabaseCleanup implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        tableNames = entityManager.getMetamodel()
+            .getEntities()
+            .stream()
+            .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+            .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+        entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+    }
+}

--- a/src/test/java/woohaengsi/qnadiary/InitRestDocsTest.java
+++ b/src/test/java/woohaengsi/qnadiary/InitRestDocsTest.java
@@ -1,0 +1,56 @@
+package woohaengsi.qnadiary;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.config.ObjectMapperConfig;
+import io.restassured.config.RestAssuredConfig;
+import io.restassured.internal.mapping.Jackson2Mapper;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import woohaengsi.qnadiary.auth.jwt.JwtProvider;
+
+public class InitRestDocsTest {
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    @LocalServerPort
+    protected int port;
+
+    protected RequestSpecification spec;
+
+    {
+        setUpRestAssured();
+    }
+
+    @BeforeEach
+    void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
+
+        this.spec = new RequestSpecBuilder()
+            .setPort(port)
+            .addFilter(documentationConfiguration(restDocumentation)
+                .operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint()))
+            .build();
+    }
+
+    private void setUpRestAssured() {
+        RestAssured.config = RestAssuredConfig.config()
+            .objectMapperConfig(
+                new ObjectMapperConfig(
+                    new Jackson2Mapper((type, charset) -> objectMapper)
+                )
+            );
+    }
+}

--- a/src/test/java/woohaengsi/qnadiary/IntegrationTest.java
+++ b/src/test/java/woohaengsi/qnadiary/IntegrationTest.java
@@ -1,0 +1,21 @@
+package woohaengsi.qnadiary;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Documented
+@Tag("integration")
+public @interface IntegrationTest {
+
+}

--- a/src/test/java/woohaengsi/qnadiary/RestAssuredAndRestDocsTest.java
+++ b/src/test/java/woohaengsi/qnadiary/RestAssuredAndRestDocsTest.java
@@ -1,0 +1,16 @@
+package woohaengsi.qnadiary;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationExtension;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(RestDocumentationExtension.class)
+@IntegrationTest
+public @interface RestAssuredAndRestDocsTest {
+
+}

--- a/src/test/java/woohaengsi/qnadiary/answer/AnswerRestDocsTest.java
+++ b/src/test/java/woohaengsi/qnadiary/answer/AnswerRestDocsTest.java
@@ -8,10 +8,12 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static woohaengsi.qnadiary.auth.oauth.type.ResourceServer.APPLE;
 
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import woohaengsi.qnadiary.DatabaseCleanup;
 import woohaengsi.qnadiary.InitRestDocsTest;
 import woohaengsi.qnadiary.RestAssuredAndRestDocsTest;
 import woohaengsi.qnadiary.answer.repository.AnswerRepository;
@@ -22,7 +24,10 @@ import woohaengsi.qnadiary.question.repository.QuestionRepository;
 
 @DisplayName("API 문서화 : 답변 조회")
 @RestAssuredAndRestDocsTest
-public class AnswerRestDocsTest extends InitRestDocsTest {
+class AnswerRestDocsTest extends InitRestDocsTest {
+
+    @Autowired
+    DatabaseCleanup databaseCleanup;
 
     @Autowired
     AnswerRepository answerRepository;
@@ -33,12 +38,14 @@ public class AnswerRestDocsTest extends InitRestDocsTest {
 
     @BeforeEach
     void setUp() {
-        answerRepository.deleteAllInBatch();
-        memberRepository.deleteAllInBatch();
-        questionRepository.deleteAllInBatch();
-
         memberRepository.save(Member.of(APPLE, "test", "user1", "test@woohaengsi.com", "image.url"));
         questionRepository.save(new Question("첫번째 질문"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanup.afterPropertiesSet();
+        databaseCleanup.execute();
     }
 
     @Test

--- a/src/test/java/woohaengsi/qnadiary/answer/AnswerRestDocsTest.java
+++ b/src/test/java/woohaengsi/qnadiary/answer/AnswerRestDocsTest.java
@@ -1,0 +1,63 @@
+package woohaengsi.qnadiary.answer;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static woohaengsi.qnadiary.auth.oauth.type.ResourceServer.APPLE;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import woohaengsi.qnadiary.InitRestDocsTest;
+import woohaengsi.qnadiary.RestAssuredAndRestDocsTest;
+import woohaengsi.qnadiary.answer.repository.AnswerRepository;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@DisplayName("API 문서화 : 답변 조회")
+@RestAssuredAndRestDocsTest
+public class AnswerRestDocsTest extends InitRestDocsTest {
+
+    @Autowired
+    AnswerRepository answerRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+
+    @BeforeEach
+    void setUp() {
+        answerRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        questionRepository.deleteAllInBatch();
+
+        memberRepository.save(Member.of(APPLE, "test", "user1", "test@woohaengsi.com", "image.url"));
+        questionRepository.save(new Question("첫번째 질문"));
+    }
+
+    @Test
+    @DisplayName("답변을 정상적으로 생성하면 해당 질문 id와 정상 상태 코드를 반환한다.")
+    void answer_create() {
+        String accessToken  = jwtProvider.issueAccessToken(1L);
+        Map<String, String> requestBody = Map.of("questionId", "1", "content", "우리 모두 화이팅입니다아아아아아아아");
+
+    	given(this.spec)
+            .contentType(APPLICATION_JSON_VALUE)
+            .header(AUTHORIZATION, accessToken)
+            .body(requestBody)
+
+        .when()
+            .post("/answer")
+
+            .then()
+                .statusCode(OK.value())
+                .body("questionId", equalTo(1));
+    }
+
+}

--- a/src/test/java/woohaengsi/qnadiary/answer/repository/AnswerRepositoryTest.java
+++ b/src/test/java/woohaengsi/qnadiary/answer/repository/AnswerRepositoryTest.java
@@ -1,0 +1,45 @@
+package woohaengsi.qnadiary.answer.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import woohaengsi.qnadiary.answer.domain.Answer;
+import woohaengsi.qnadiary.auth.oauth.type.ResourceServer;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@DataJpaTest
+class AnswerRepositoryTest {
+
+    @Autowired
+    private AnswerRepository answerRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private QuestionRepository questionRepository;
+
+    @Test
+    @DisplayName("답변을 생성하면 저장된 답변의 갯수가 증가한다")
+    void create_increase_size() {
+    	// given
+        Member member = Member.of(ResourceServer.KAKAO, "TEST", "TEST", "TEST", "TEST");
+        Question question = new Question("질문1");
+        String content = "답변1";
+        Answer answer = new Answer(member, question, content);
+        int oldSize = answerRepository.findAll().size();
+        memberRepository.save(member);
+        questionRepository.save(question);
+
+        // when
+        answerRepository.save(answer);
+        int newSize = answerRepository.findAll().size();
+
+        // then
+        assertThat(newSize).isEqualTo(oldSize + 1);
+    }
+}

--- a/src/test/java/woohaengsi/qnadiary/answer/service/AnswerServiceTest.java
+++ b/src/test/java/woohaengsi/qnadiary/answer/service/AnswerServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import woohaengsi.qnadiary.DatabaseCleanup;
 import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
 import woohaengsi.qnadiary.answer.repository.AnswerRepository;
 import woohaengsi.qnadiary.auth.oauth.type.ResourceServer;
@@ -22,6 +23,8 @@ import woohaengsi.qnadiary.question.repository.QuestionRepository;
 class AnswerServiceTest {
 
     @Autowired
+    DatabaseCleanup databaseCleanup;
+    @Autowired
     AnswerService answerService;
     @Autowired
     AnswerRepository answerRepository;
@@ -32,7 +35,8 @@ class AnswerServiceTest {
 
     @AfterEach
     void tearDown() {
-        answerRepository.deleteAllInBatch();
+        databaseCleanup.afterPropertiesSet();
+        databaseCleanup.execute();
     }
 
     @Test

--- a/src/test/java/woohaengsi/qnadiary/answer/service/AnswerServiceTest.java
+++ b/src/test/java/woohaengsi/qnadiary/answer/service/AnswerServiceTest.java
@@ -1,0 +1,56 @@
+package woohaengsi.qnadiary.answer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.repository.AnswerRepository;
+import woohaengsi.qnadiary.auth.oauth.type.ResourceServer;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class AnswerServiceTest {
+
+    @Autowired
+    AnswerService answerService;
+    @Autowired
+    AnswerRepository answerRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+
+    @AfterEach
+    void tearDown() {
+        answerRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("답변을 저장한다.")
+    void create_answer() {
+    	// given
+        Member member = Member.of(ResourceServer.KAKAO, "TEST", "TEST", "TEST", "TEST");
+        Question question = new Question("질문1");
+
+        memberRepository.save(member);
+        questionRepository.save(question);
+
+        AnswerCreateRequest request = new AnswerCreateRequest(1L, "답변1");
+
+    	// when
+        Map<String, Long> map = answerService.create(request, 1L);
+
+        // then
+        assertThat(map.get("questionId")).isEqualTo(request.questionId());
+    }
+}

--- a/src/test/java/woohaengsi/qnadiary/question/service/QuestionServiceTest.java
+++ b/src/test/java/woohaengsi/qnadiary/question/service/QuestionServiceTest.java
@@ -1,0 +1,87 @@
+package woohaengsi.qnadiary.question.service;
+
+import static woohaengsi.qnadiary.auth.oauth.type.ResourceServer.APPLE;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import woohaengsi.qnadiary.DatabaseCleanup;
+import woohaengsi.qnadiary.answer.dto.AnswerCreateRequest;
+import woohaengsi.qnadiary.answer.service.AnswerService;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.dto.QuestionReadResponse;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class QuestionServiceTest {
+
+    @Autowired
+    DatabaseCleanup databaseCleanup;
+    @Autowired
+    QuestionService questionService;
+    @Autowired
+    AnswerService answerService;
+    @Autowired
+    QuestionRepository questionRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        questionRepository.save(new Question("1번 질문"));
+        questionRepository.save(new Question("2번 질문"));
+        memberRepository.save(Member.of(APPLE, "resource_id", "name", "email", "image"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanup.afterPropertiesSet();
+        databaseCleanup.execute();
+    }
+
+    @Test
+    @DisplayName("현재 순서의 질문을 조회한다.")
+    void find_now_question() {
+    	// given
+        Member findMember = memberRepository.findById(1L).orElseThrow(IllegalArgumentException::new);
+        Question question1 = questionRepository.findById(1L)
+            .orElseThrow(IllegalArgumentException::new);
+        // when
+        QuestionReadResponse findQuestion = questionService.findBy(findMember.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+            softAssertions.assertThat(findMember.getCurrentQuestionNumber()).isEqualTo(question1.getId());
+            softAssertions.assertThat(findQuestion.getId()).isEqualTo(question1.getId());
+            softAssertions.assertThat(findQuestion.getContent()).isEqualTo(question1.getContent());
+        });
+    }
+
+    @Test
+    @DisplayName("한번 질문을 답변하면 다음 질문을 조회한다.")
+    void find_next_question() {
+        // given
+        Question question2 = questionRepository.findById(2L)
+            .orElseThrow(IllegalArgumentException::new);
+        answerService.create(new AnswerCreateRequest(1L, "대답"), 1L);
+        Member findMember = memberRepository.findById(1L).orElseThrow(IllegalArgumentException::new);
+        // when
+        QuestionReadResponse findQuestion = questionService.findBy(findMember.getId());
+
+        // then
+        SoftAssertions.assertSoftly(softAssertions -> {
+                softAssertions.assertThat(findMember.getCurrentQuestionNumber()).isEqualTo(question2.getId());
+                softAssertions.assertThat(findQuestion.getId()).isEqualTo(question2.getId());
+                softAssertions.assertThat(findQuestion.getContent()).isEqualTo(question2.getContent());
+            }
+        );
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#9 

<br>

### 📝 구현 내용

- 답변의 생성, 상세 조회, 수정, 삭제 기능 구현
- 답변을 생성하면 유저의 현재 질문 번호가 다음 문제를 가리키도록 구현
- 유저가 답변해야할 질문 조회 기능 구현 

<br>

### 💡 결과 & 참고 자료
