### PR TITLE
[feat] 질문 모음을 반복할 수 있는 기능 구현

### DIFF
--- a/src/main/java/woohaengsi/qnadiary/member/MemberController.java
+++ b/src/main/java/woohaengsi/qnadiary/member/MemberController.java
@@ -1,0 +1,26 @@
+package woohaengsi.qnadiary.member;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import woohaengsi.qnadiary.auth.jwt.JwtProvider;
+import woohaengsi.qnadiary.member.service.MemberService;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
+
+    @PatchMapping("/member/question/repeat")
+    public void repeatQuestionCycle(@RequestHeader("Authorization") String accessToken) {
+        Long memberId = decodeAccessToken(accessToken);
+        memberService.repeatQuestionCycle(memberId);
+    }
+
+    private Long decodeAccessToken(String accessToken) {
+        return jwtProvider.decode(accessToken);
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/member/domain/Member.java
+++ b/src/main/java/woohaengsi/qnadiary/member/domain/Member.java
@@ -41,6 +41,8 @@ public class Member extends BaseEntity {
     private String profileImageUrl;
     private String refreshToken;
     private Long currentQuestionNumber;
+    @Enumerated(value = EnumType.STRING)
+    private QuestionSetSize questionSetSize;
 
     @Builder
     private Member(ResourceServer resourceServer, String resourceServerId, String nickname,
@@ -52,6 +54,7 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
         this.refreshToken = refreshToken;
         this.currentQuestionNumber = 1L;
+        this.questionSetSize = QuestionSetSize.MONTH;
     }
 
     public static Member of(ResourceServer resourceServer, String resourceServerId, String nickname,
@@ -71,5 +74,9 @@ public class Member extends BaseEntity {
 
     public void increaseCurrentQuestionNumber() {
         this.currentQuestionNumber++;
+    }
+
+    public void repeatQuestionCycle() {
+        this.currentQuestionNumber -= this.questionSetSize.getSize();
     }
 }

--- a/src/main/java/woohaengsi/qnadiary/member/domain/QuestionSetSize.java
+++ b/src/main/java/woohaengsi/qnadiary/member/domain/QuestionSetSize.java
@@ -1,0 +1,13 @@
+package woohaengsi.qnadiary.member.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum QuestionSetSize {
+    MONTH(30);
+
+    private final int size;
+    QuestionSetSize(int size) {
+        this.size = size;
+    }
+}

--- a/src/main/java/woohaengsi/qnadiary/member/service/MemberService.java
+++ b/src/main/java/woohaengsi/qnadiary/member/service/MemberService.java
@@ -1,0 +1,27 @@
+package woohaengsi.qnadiary.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void repeatQuestionCycle(Long memberId) {
+        Member findMember = findMemberBy(memberId);
+        findMember.repeatQuestionCycle();
+
+    }
+
+    private Member findMemberBy(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    }
+}

--- a/src/test/java/woohaengsi/qnadiary/member/service/MemberServiceTest.java
+++ b/src/test/java/woohaengsi/qnadiary/member/service/MemberServiceTest.java
@@ -1,0 +1,85 @@
+package woohaengsi.qnadiary.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static woohaengsi.qnadiary.auth.oauth.type.ResourceServer.APPLE;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import woohaengsi.qnadiary.DatabaseCleanup;
+import woohaengsi.qnadiary.answer.repository.AnswerRepository;
+import woohaengsi.qnadiary.answer.service.AnswerService;
+import woohaengsi.qnadiary.member.domain.Member;
+import woohaengsi.qnadiary.member.repository.MemberRepository;
+import woohaengsi.qnadiary.question.domain.Question;
+import woohaengsi.qnadiary.question.repository.QuestionRepository;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class MemberServiceTest {
+
+    @Autowired
+    DatabaseCleanup databaseCleanup;
+    @Autowired
+    MemberService memberService;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    AnswerService answerService;
+    @Autowired
+    AnswerRepository answerRepository;
+    @Autowired
+    QuestionRepository questionRepository;
+
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanup.afterPropertiesSet();
+        databaseCleanup.execute();
+    }
+
+    @BeforeEach
+    void setUp() {
+        questionRepository.save(new Question("1번 질문"));
+        questionRepository.save(new Question("2번 질문"));
+        memberRepository.save(Member.of(APPLE, "resource_id", "name", "email", "image"));
+    }
+
+    @Test
+    @DisplayName("30개의 질문에 답변하고 반복을 요청하면 다음 질문 번호는 1번이다.")
+    void repeat_question_cycle_1() {
+    	// given
+        Member findMember = memberRepository.findById(1L).orElseThrow(IllegalArgumentException::new);
+        for (int i=0; i < 30; i++) {
+            findMember.increaseCurrentQuestionNumber();
+        }
+        findMember.repeatQuestionCycle();
+
+    	// when
+        Long curQuestionNumber = findMember.getCurrentQuestionNumber();
+
+    	// then
+        assertThat(curQuestionNumber).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("60개의 질문에 답변하고 반복을 요청하면 다음 질문 번호는 31번이다.")
+    void repeat_question_cycle_2() {
+        // given
+        Member findMember = memberRepository.findById(1L).orElseThrow(IllegalArgumentException::new);
+        for (int i=0; i < 60; i++) {
+            findMember.increaseCurrentQuestionNumber();
+        }
+        findMember.repeatQuestionCycle();
+
+        // when
+        Long curQuestionNumber = findMember.getCurrentQuestionNumber();
+
+        // then
+        assertThat(curQuestionNumber).isEqualTo(31);
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

#13 
<br>

### 📝 구현 내용

- 회원이 현재 설정한 질문 모음의 크기만큼 질문을 반복할 수 있는 기능
- 현재는 30개만 가능하나 추후 변경 가능할 수 있도록 Enum을 통해 구현

<br>

### 💡 결과 & 참고 자료

-  ex) 60번까지 질문에 답하고 반복을 요구하는 경우 31번부터 다시 질문이 반복된다.
